### PR TITLE
Further sync script refactors

### DIFF
--- a/sync
+++ b/sync
@@ -8,6 +8,7 @@ import psycopg2.extras
 import json
 import hashlib
 import time
+from urllib.parse import urljoin
 
 
 WATCHED_EXTS = [".sh", ".sql"]
@@ -80,8 +81,12 @@ class FileUploader:
         return os.environ.get('SERVER_URL', "https://train.skillerwhale.com")
 
     @property
+    def updates_path(self):
+        return f'attendances/{self.attendance_id}/file_snapshots'
+
+    @property
     def updates_uri(self):
-        return f"{self.hostname}/attendances/{self.attendance_id}/file_snapshots"
+        return urljoin(self.hostname, self.updates_path)
 
     @staticmethod
     def get_file_data(path):


### PR DESCRIPTION
Follows #2 

This PR updates the `Watcher` and `FileUploader` classes with their 
equivalents from the latest version in the python-essentials repo. I
suspect that the original code here was a copy of the old version of
that repository, and the newer version benefits from:

* Cleaner, better structured code
* Better tracking of files (it adds new files as well as modified ones)

Longer term I think we want to standardise this somewhere so several repos 
can share the same sync script.

- Replace the FileUploader class with python-essentials Updater
- Replace the Watcher class with python-essentials Watcher
