### PR TITLE
Only mount the src directory in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,6 @@ services:
     links:
       - db
     volumes:
-      - .:/src
+      - ./src:/src
     stdin_open: true
     tty: true


### PR DESCRIPTION
The code that the user will be running, and editing is just that in the
src directory, so other code does not need to be mounted.

If we mount the whole repo into the src directory, then we end up with
confusing update messages, placing the files in src/src

sync_1  | Uploading: src/src/script.sql
