### PR TITLE
Catch postgres execution errors

### DIFF
--- a/sync
+++ b/sync
@@ -71,9 +71,9 @@ class PgExec:
                 print(f"Could not find the database, retrying in {self.RETRY_TIME}s")
                 time.sleep(self.RETRY_TIME)
 
-    def execute_query(self, query):
+    def execute_sql(self, sql):
         with self.connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
-            cursor.execute(query)
+            cursor.execute(sql)
             return cursor.fetchall()
 
     def file_changed(self, path):
@@ -84,7 +84,7 @@ class PgExec:
             contents = f.read()
 
         try:
-            query_results = self.execute_query(contents)
+            query_results = self.execute_sql(contents)
         except psycopg2.Error as err:
             self.connection.rollback()
             print("POSTGRES ERROR:", err)


### PR DESCRIPTION
Previously, if a postgres file update happened, causing the script to be invalid, psycopg2 would raise an error, and the process would terminate. For example, in this execution I started with a valid SQL script, updated it (keeping it valid), updated it (with an invalid table name) and then fixed it, and updated the file a couple more times:

After the invalid SQL, the process errored, and then no longer ran. This PR aims to fix that issue by catching SQL errors and handling them gracefully.

```
sync_1  | We're going to start watching this directory for changes so that the trainer can see your progress, using id your_attendance_id_goes_here
sync_1  | dbname=postgres user=postgres password=123 host=db
sync_1  | Uploading: src/src/script.sql
sync_1  | RUNNING FILE src/src/script.sql
sync_1  | 
sync_1  | --- ROW ---
sync_1  | ID: 1
sync_1  | PROD_NAME: Book
sync_1  | 
sync_1  | --- ROW ---
sync_1  | ID: 2
sync_1  | PROD_NAME: House
sync_1  | 
sync_1  | Status: 404
sync_1  | Trainee ID incorrect
sync_1  | 
sync_1  | Uploading: src/src/script.sql Status: 404
sync_1  | Trainee ID incorrect
sync_1  | 
sync_1  | 
sync_1  | RUNNING FILE src/src/script.sql
sync_1  | 
sync_1  | --- ROW ---
sync_1  | ID: 1
sync_1  | PROD_NAME: Book
sync_1  | 
sync_1  | --- ROW ---
sync_1  | ID: 2
sync_1  | PROD_NAME: House
sync_1  | 
sync_1  | 
sync_1  | RUNNING FILE src/src/script.sql
sync_1  | 
db_1    | 2020-06-13 17:54:26.031 UTC [27] ERROR:  relation "productsas" does not exist at character 15
db_1    | 2020-06-13 17:54:26.031 UTC [27] STATEMENT:  SELECT * FROM productsas;
db_1    | 
sync_1  | Traceback (most recent call last):
sync_1  |   File "sync", line 186, in <module>
sync_1  |     skiller_whale_sync()
sync_1  |   File "sync", line 49, in skiller_whale_sync
sync_1  |     pg_update()
sync_1  |   File "sync", line 30, in pg_update
sync_1  |     watcher.poll_for_changes()
sync_1  |   File "sync", line 180, in poll_for_changes
sync_1  |     self._check_dir_for_changes(self.base_path)
sync_1  |   File "sync", line 174, in _check_dir_for_changes
sync_1  |     self._check_dir_for_changes(new_path)
sync_1  |   File "sync", line 176, in _check_dir_for_changes
sync_1  |     self._respond_to_file_change(new_path)
sync_1  |   File "sync", line 163, in _respond_to_file_change
sync_1  |     self.responder.file_changed(path)
sync_1  |   File "sync", line 82, in file_changed
sync_1  |     cursor.execute(contents)
sync_1  |   File "/usr/local/lib/python3.8/site-packages/psycopg2/extras.py", line 248, in execute
sync_1  |     return super(RealDictCursor, self).execute(query, vars)
sync_1  | psycopg2.errors.UndefinedTable: relation "productsas" does not exist
sync_1  | LINE 1: SELECT * FROM productsas;
sync_1  |                       ^
sync_1  | 
sync_1  | Uploading: src/src/script.sql Status: 404
sync_1  | Trainee ID incorrect
sync_1  | 
sync_1  | Uploading: src/src/script.sql Status: 404
sync_1  | Trainee ID incorrect
```

