### PR TITLE
Require a major version of dependencies, rather than anything more specific

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3-alpine3.11
 
 RUN apk add --update --no-cache gcc=9.3.0-r0               \
                                 musl-dev=1.1.24-r3         \
-                                postgresql-dev=12.7-r0     \
-                                postgresql-libs=12.7-r0    \
-                                postgresql-client=12.7-r0
+                                postgresql-dev=~12       \
+                                postgresql-libs=~12      \
+                                postgresql-client=~12
 
 RUN pip3 install requests==2.25.1  \
                  psycopg2==2.8.6   \


### PR DESCRIPTION
We've had a couple of learners stung by this during setup - other dependencies now rely on version 12.8 of the Postgres libs. Rather than bump the minor version, I thought it'd make more sense to be less specific.
