### PR TITLE
Make the sync tool ignore links on Unix systems

### DIFF
--- a/lib/watcher.py
+++ b/lib/watcher.py
@@ -9,7 +9,7 @@ WATCHED_EXTS = [".sh", ".sql"]
 
 
 class Watcher:
-    def __init__(self, responder, base_path='.', output_lock=threading.Lock()):
+    def __init__(self, responder, base_path=".", output_lock=threading.Lock()):
         self.responder = responder
         self.base_path = base_path
         self.output_lock = output_lock
@@ -50,7 +50,7 @@ class Watcher:
             if os.path.isdir(new_path):
                 # Recursively check subdirectories
                 self._check_dir_for_changes(new_path)
-            else:
+            elif os.path.isfile(new_path):
                 self._respond_to_file_change(new_path)
 
     def poll_for_changes(self, wait_time=1, loop_callback=lambda: None):
@@ -71,5 +71,3 @@ class Watcher:
                 self._first_pass = False
 
             time.sleep(wait_time)  # Poll for changes every `wait_time` seconds
-
-


### PR DESCRIPTION
When editing a file, Emacs creates lock in the same directory under the form of a link, e.g.

```
leo@gandalf:~/devel/skillerwhale/advanced-postgres$ ll -a src/indexes/
total 28
drwxrwxr-x  2 leo leo 4096 Jul 12 10:18 .
drwxrwxr-x 18 leo leo 4096 Oct 31  2022 ..
-rw-rw-r--  1 leo leo    9 Oct 27  2022 .db_name
lrwxrwxrwx  1 leo leo   29 Jul 12 10:18 .#exercises.1.sql -> leo@gandalf.410731:1688110426
-rw-rw-r--  1 leo leo 4636 Jul 12 10:17 exercises.1.sql
-rw-rw-r--  1 leo leo  688 Jul 12 10:11 exercises.2.sql
-rw-rw-r--  1 leo leo  155 Oct 27  2022 .pre.exercises.sql
```

This change makes sure the sync just watches regular files and ignores other type of items.